### PR TITLE
Simplify the implementation of the crate and fix #1 at the same time.

### DIFF
--- a/wasm-init/Cargo.toml
+++ b/wasm-init/Cargo.toml
@@ -14,7 +14,6 @@ auto-init = []
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 gensym = "0.1"
-paste = "1"
 
 [package.metadata.docs.rs]
 targets = [ "wasm32-unknown-unknown" ]

--- a/wasm-init/src/wasm.rs
+++ b/wasm-init/src/wasm.rs
@@ -5,8 +5,7 @@ use wasm_bindgen::prelude::*;
 #[doc(hidden)]
 pub mod __macrodeps {
 	pub use gensym::gensym;
-	pub use paste::item;
-	pub use wasm_bindgen::prelude::wasm_bindgen;
+	pub use std::{concat, stringify};
 }
 
 static INIT_DONE: AtomicBool = AtomicBool::new(false);
@@ -50,12 +49,15 @@ pub fn wasm_init() {
 #[macro_export]
 macro_rules! __wasm_init_impl {
 	($gensym:ident, $($input:tt)*) => {
-		$crate::__macrodeps::item! {
-			#[$crate::__macrodeps::wasm_bindgen]
-			pub fn [<__wasm_init $gensym>]() {
+		const _: () = {
+			#[export_name = $crate::__macrodeps::concat!(
+				"__wasm_init",
+				$crate::__macrodeps::stringify!($gensym)
+			)]
+			pub extern "C" fn init() {
 				$($input)*
 			}
-		}
+		};
 	};
 }
 


### PR DESCRIPTION
Drops the `paste` crate and does not bother to use `#[wasm_bindgen]` to generate the exported init function. Instead, exports a plain `extern "C"` function and uses uses `#[export = name]` to set its name, as `wasm-bindgen` would have done.

This is both simpler, and also does not require that the calling crate have `wasm_bindgen` as a direct dependency, so it fixes #1 at the same time.